### PR TITLE
子タスク1: 論理名カラム機能の設定オプション追加

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -32,6 +32,9 @@ const SchemaFileName = "schema.json"
 // DefaultERDistance is the default distance between tables that display relations in the ER.
 var DefaultERDistance = 1
 
+// DefaultLogicalNameDelimiter is the default delimiter for logical name separation.
+const DefaultLogicalNameDelimiter = "|"
+
 // Config is tbls config.
 type Config struct {
 	Name   string   `yaml:"name"`
@@ -73,11 +76,12 @@ type DSN struct {
 
 // Format is document format setting.
 type Format struct {
-	Adjust                   bool     `yaml:"adjust,omitempty"`
-	Sort                     bool     `yaml:"sort,omitempty"`
-	Number                   bool     `yaml:"number,omitempty"`
-	ShowOnlyFirstParagraph   bool     `yaml:"showOnlyFirstParagraph,omitempty"`
-	HideColumnsWithoutValues []string `yaml:"hideColumnsWithoutValues,omitempty"`
+	Adjust                   bool        `yaml:"adjust,omitempty"`
+	Sort                     bool        `yaml:"sort,omitempty"`
+	Number                   bool        `yaml:"number,omitempty"`
+	ShowOnlyFirstParagraph   bool        `yaml:"showOnlyFirstParagraph,omitempty"`
+	HideColumnsWithoutValues []string    `yaml:"hideColumnsWithoutValues,omitempty"`
+	LogicalName              LogicalName `yaml:"logicalName,omitempty"`
 }
 
 // ER is er setting.
@@ -95,6 +99,13 @@ type ER struct {
 type ShowColumnTypes struct {
 	Related bool `yaml:"related,omitempty"`
 	Primary bool `yaml:"primary,omitempty"`
+}
+
+// LogicalName is logical name setting.
+type LogicalName struct {
+	Enabled        bool   `yaml:"enabled,omitempty"`
+	Delimiter      string `yaml:"delimiter,omitempty"`
+	FallbackToName bool   `yaml:"fallbackToName,omitempty"`
 }
 
 // AdditionalRelation is the struct for table relation from yaml.
@@ -288,6 +299,10 @@ func (c *Config) setDefault() error {
 
 	if c.ER.Distance == nil {
 		c.ER.Distance = &DefaultERDistance
+	}
+
+	if c.Format.LogicalName.Delimiter == "" {
+		c.Format.LogicalName.Delimiter = DefaultLogicalNameDelimiter
 	}
 
 	return nil
@@ -592,6 +607,21 @@ func (c *Config) NeedToGenerateERImages() bool {
 		return false
 	}
 	return true
+}
+
+func (c *Config) IsLogicalNameEnabled() bool {
+	return c.Format.LogicalName.Enabled
+}
+
+func (c *Config) LogicalNameDelimiter() string {
+	if c.Format.LogicalName.Delimiter != "" {
+		return c.Format.LogicalName.Delimiter
+	}
+	return DefaultLogicalNameDelimiter
+}
+
+func (c *Config) LogicalNameFallbackToName() bool {
+	return c.Format.LogicalName.FallbackToName
 }
 
 func (c *Config) detectShowColumnsForER(s *schema.Schema) error {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -36,6 +36,15 @@ func TestLoadDefault(t *testing.T) {
 	if want := 1; *config.ER.Distance != want {
 		t.Errorf("got %v\nwant %v", config.ER.Distance, want)
 	}
+	if want := "|"; config.Format.LogicalName.Delimiter != want {
+		t.Errorf("got %v\nwant %v", config.Format.LogicalName.Delimiter, want)
+	}
+	if want := false; config.Format.LogicalName.Enabled != want {
+		t.Errorf("got %v\nwant %v", config.Format.LogicalName.Enabled, want)
+	}
+	if want := false; config.Format.LogicalName.FallbackToName != want {
+		t.Errorf("got %v\nwant %v", config.Format.LogicalName.FallbackToName, want)
+	}
 }
 
 func TestLoadConfigFile(t *testing.T) {
@@ -685,6 +694,43 @@ func TestDetectShowColumnsForER(t *testing.T) {
 				t.Errorf("got %v\nwant %v", gotRelationCount, tt.wantRelationCount)
 			}
 		})
+	}
+}
+
+func TestLogicalNameConfigStructure(t *testing.T) {
+	// Test basic structure and default values only (scope of #2)
+	config, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Test default delimiter is set
+	if got := config.LogicalNameDelimiter(); got != DefaultLogicalNameDelimiter {
+		t.Errorf("LogicalNameDelimiter() = %v, want %v", got, DefaultLogicalNameDelimiter)
+	}
+
+	// Test helper methods exist and return correct types
+	if enabled := config.IsLogicalNameEnabled(); enabled != false {
+		t.Errorf("IsLogicalNameEnabled() should return false by default, got %v", enabled)
+	}
+
+	if fallback := config.LogicalNameFallbackToName(); fallback != false {
+		t.Errorf("LogicalNameFallbackToName() should return false by default, got %v", fallback)
+	}
+
+	// Test that structure can be accessed
+	config.Format.LogicalName.Enabled = true
+	config.Format.LogicalName.Delimiter = ";"
+	config.Format.LogicalName.FallbackToName = true
+
+	if !config.IsLogicalNameEnabled() {
+		t.Error("IsLogicalNameEnabled() should return true after setting Enabled = true")
+	}
+	if config.LogicalNameDelimiter() != ";" {
+		t.Errorf("LogicalNameDelimiter() = %v, want ';'", config.LogicalNameDelimiter())
+	}
+	if !config.LogicalNameFallbackToName() {
+		t.Error("LogicalNameFallbackToName() should return true after setting FallbackToName = true")
 	}
 }
 


### PR DESCRIPTION
## 概要
論理名カラム機能の基盤となる設定オプションをtblsの設定システムに追加

## 変更内容

### 新規追加
- `LogicalName`構造体を定義
  - `Enabled`: 論理名機能の有効/無効切り替え
  - `Delimiter`: 区切り文字の設定（デフォルト: `|`）
  - `FallbackToName`: フォールバック動作の設定

### 設定アクセス用ヘルパーメソッド
- `IsLogicalNameEnabled()`: 論理名機能が有効かチェック
- `LogicalNameDelimiter()`: 区切り文字を取得（デフォルト値対応）
- `LogicalNameFallbackToName()`: フォールバック設定を取得

### テスト
- 設定構造の基本動作テストを追加
- デフォルト値の設定確認

## 設定例
```yaml
format:
  logicalName:
    enabled: true
    delimiter: "|"
    fallbackToName: true
```

## Issue
Closes #2

## 次のステップ
この基盤設定を使用して、子タスク2以降でコメント分割ロジックとテンプレート更新を実装します。

🤖 Generated with [Claude Code](https://claude.ai/code)