### PR TITLE
fix: 論理名設定の読み込み問題を修正 (ISSUE #15)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -103,9 +103,9 @@ type ShowColumnTypes struct {
 
 // LogicalName is logical name setting.
 type LogicalName struct {
-	Enabled        bool   `yaml:"enabled,omitempty"`
+	Enabled        bool   `yaml:"enabled"`
 	Delimiter      string `yaml:"delimiter,omitempty"`
-	FallbackToName bool   `yaml:"fallbackToName,omitempty"`
+	FallbackToName bool   `yaml:"fallbackToName"`
 }
 
 // AdditionalRelation is the struct for table relation from yaml.

--- a/config/yaml.go
+++ b/config/yaml.go
@@ -51,11 +51,12 @@ func (f Format) MarshalYAML() ([]byte, error) {
 
 func (f *Format) UnmarshalYAML(data []byte) error {
 	s := struct {
-		Adjust                   bool        `yaml:"adjust,omitempty"`
-		Sort                     bool        `yaml:"sort,omitempty"`
-		Number                   bool        `yaml:"number,omitempty"`
-		ShowOnlyFirstParagraph   bool        `yaml:"showOnlyFirstParagraph,omitempty"`
-		HideColumnsWithoutValues interface{} `yaml:"hideColumnsWithoutValues,omitempty"`
+		Adjust                   bool         `yaml:"adjust,omitempty"`
+		Sort                     bool         `yaml:"sort,omitempty"`
+		Number                   bool         `yaml:"number,omitempty"`
+		ShowOnlyFirstParagraph   bool         `yaml:"showOnlyFirstParagraph,omitempty"`
+		HideColumnsWithoutValues interface{}  `yaml:"hideColumnsWithoutValues,omitempty"`
+		LogicalName              LogicalName  `yaml:"logicalName,omitempty"`
 	}{}
 	if err := yaml.Unmarshal(data, &s); err != nil {
 		return err
@@ -64,6 +65,7 @@ func (f *Format) UnmarshalYAML(data []byte) error {
 	f.Sort = s.Sort
 	f.Number = s.Number
 	f.ShowOnlyFirstParagraph = s.ShowOnlyFirstParagraph
+	f.LogicalName = s.LogicalName
 	switch v := s.HideColumnsWithoutValues.(type) {
 	case bool:
 		if v {


### PR DESCRIPTION
## 概要

ISSUE #15で報告された論理名機能のYAML設定読み込み問題を修正しました。

## 問題の詳細

論理名機能が設定ファイルで有効化（`enabled: true`）しても動作しない問題がありました。

### 根本原因

1. **omitemptyタグ問題**: `LogicalName`構造体のboolean型フィールドに`omitempty`タグが設定されており、true値が正しく読み込まれない
2. **カスタムUnmarshalYAMLの不備**: `Format`構造体のカスタム`UnmarshalYAML`メソッドで`LogicalName`フィールドが処理されていない

## 修正内容

### 1. LogicalName構造体のYAMLタグ修正

```go
// 修正前
type LogicalName struct {
    Enabled        bool   `yaml:"enabled,omitempty"`
    FallbackToName bool   `yaml:"fallbackToName,omitempty"`
}

// 修正後  
type LogicalName struct {
    Enabled        bool   `yaml:"enabled"`
    FallbackToName bool   `yaml:"fallbackToName"`
}
```

### 2. Format.UnmarshalYAMLメソッドの修正

```go
// LogicalNameフィールドの処理を追加
s := struct {
    // ... 既存フィールド
    LogicalName LogicalName `yaml:"logicalName,omitempty"`
}{}

// フィールドの代入処理を追加
f.LogicalName = s.LogicalName
```

## 検証結果

### 機能テスト
- PostgreSQLデータベースで論理名機能が正常に動作することを確認
- 生成されたドキュメントに論理名カラムが表示されることを確認
- コメント分割機能が正常に動作することを確認

### テスト結果
- 全config関連テストが通過: ✅
- 統合テストが通過: ✅

## サンプル出力

修正後、以下のような論理名付きドキュメントが正常に生成されます：

```markdown
| 名前 | 論理名 | データ型 | ...
| ---- | ------ | -------- | ...
| id | ユーザーID | integer | ...
| username | ユーザー名 | varchar(50) | ...
```

## 関連ISSUE

- Closes #15

🤖 Generated with [Claude Code](https://claude.ai/code)