### PR TITLE
feat: テンプレート更新でテーブル論理名表示を実装 (#27)

### DIFF
--- a/output/dot/dot.go
+++ b/output/dot/dot.go
@@ -70,11 +70,12 @@ func (d *Dot) OutputTable(wr io.Writer, t *schema.Table) error {
 	}
 	tmpl := template.Must(template.New(t.Name).Funcs(output.Funcs(&d.config.MergedDict)).Parse(ts))
 	if err := tmpl.Execute(wr, map[string]interface{}{
-		"Table":       tables[0],
-		"Tables":      tables[1:],
-		"Relations":   relations,
-		"showComment": d.config.ER.Comment,
-		"showDef":     !d.config.ER.HideDef,
+		"Table":         tables[0],
+		"Tables":        tables[1:],
+		"Relations":     relations,
+		"DisplayFormat": d.config.TableLogicalNameDisplayFormat(),
+		"showComment":   d.config.ER.Comment,
+		"showDef":       !d.config.ER.HideDef,
 	}); err != nil {
 		return errors.WithStack(err)
 	}

--- a/output/dot/templates/table.dot.tmpl
+++ b/output/dot/templates/table.dot.tmpl
@@ -8,7 +8,7 @@ digraph "{{ .Table.Name }}" {
 
   // Tables
   "{{ .Table.Name }}" [shape=none, label=<<table border="3" cellborder="1" cellspacing="0" cellpadding="6">
-                 <tr><td bgcolor="#EFEFEF"><font face="Arial Bold" point-size="18">{{ .Table.Name | html }}</font>&nbsp;&nbsp;&nbsp;&nbsp;<font color="#666666">[{{ .Table.Type | html }}]</font>{{ if $sc }}{{ if ne .Table.Comment "" }}<br /><font color="#333333">{{ .Table.Comment | html | nl2br_slash }}</font>{{ end }}{{ end }}</td></tr>
+                 <tr><td bgcolor="#EFEFEF"><font face="Arial Bold" point-size="18">{{- if and .Table.LogicalName (ne .DisplayFormat "") }}{{ .Table.GetDisplayName .DisplayFormat | html }}{{- else }}{{ .Table.Name | html }}{{- end }}</font>&nbsp;&nbsp;&nbsp;&nbsp;<font color="#666666">[{{ .Table.Type | html }}]</font>{{ if $sc }}{{ if ne .Table.Comment "" }}<br /><font color="#333333">{{ .Table.Comment | html | nl2br_slash }}</font>{{ end }}{{ end }}</td></tr>
                  {{- range $ii, $c := .Table.Columns }}
                  {{- if $c.HideForER }}{{ continue }}{{ end }}
                  <tr><td port="{{ $c.Name | html }}" align="left">{{ $c.Name | html }}{{ if $c.HasLogicalName }} ({{ $c.LogicalName | html }}){{ end }} <font color="#666666">[{{ $c.Type | html }}]</font>{{ if $sc }}{{ if ne $c.Comment "" }} {{ $c.Comment | html | nl2space }}{{ end }}{{ end }}</td></tr>
@@ -16,7 +16,7 @@ digraph "{{ .Table.Name }}" {
               </table>>];
   {{- range $i, $t := .Tables }}
   "{{ $t.Name }}" [shape=none, label=<<table border="0" cellborder="1" cellspacing="0" cellpadding="6">
-                 <tr><td bgcolor="#EFEFEF"><font face="Arial Bold" point-size="18">{{ $t.Name | html }}</font>&nbsp;&nbsp;&nbsp;&nbsp;<font color="#666666">[{{ $t.Type | html }}]</font>{{ if $sc }}{{ if ne $t.Comment "" }}<br /><font color="#333333">{{ $t.Comment | html | nl2br_slash }}</font>{{ end }}{{ end }}</td></tr>
+                 <tr><td bgcolor="#EFEFEF"><font face="Arial Bold" point-size="18">{{- if and $t.LogicalName (ne $.DisplayFormat "") }}{{ $t.GetDisplayName $.DisplayFormat | html }}{{- else }}{{ $t.Name | html }}{{- end }}</font>&nbsp;&nbsp;&nbsp;&nbsp;<font color="#666666">[{{ $t.Type | html }}]</font>{{ if $sc }}{{ if ne $t.Comment "" }}<br /><font color="#333333">{{ $t.Comment | html | nl2br_slash }}</font>{{ end }}{{ end }}</td></tr>
                  {{- range $ii, $c := $t.Columns }}
                  {{- if $c.HideForER }}{{ continue }}{{ end }}
                  <tr><td port="{{ $c.Name | html }}" align="left">{{ $c.Name | html }}{{ if $c.HasLogicalName }} ({{ $c.LogicalName | html }}){{ end }} <font color="#666666">[{{ $c.Type | html }}]</font>{{ if $sc }}{{ if ne $c.Comment "" }} {{ $c.Comment | html | nl2space }}{{ end }}{{ end }}</td></tr>

--- a/output/md/md.go
+++ b/output/md/md.go
@@ -566,7 +566,12 @@ func (m *Md) makeTableTemplateData(t *schema.Table) map[string]interface{} {
 			if _, ok := cEncountered[r.Table.Name]; ok {
 				continue
 			}
-			childRelations = append(childRelations, fmt.Sprintf("[%s](%s%s.md)", r.Table.Name, m.config.BaseURL, mdurl.Encode(r.Table.Name)))
+			// 子テーブルの表示名を決定
+			childDisplayName := r.Table.Name
+			if m.config.IsTableLogicalNameEnabled() && r.Table.LogicalName != "" && m.config.TableLogicalNameDisplayFormat() != "" {
+				childDisplayName = r.Table.GetDisplayName(m.config.TableLogicalNameDisplayFormat())
+			}
+			childRelations = append(childRelations, fmt.Sprintf("[%s](%s%s.md)", childDisplayName, m.config.BaseURL, mdurl.Encode(r.Table.Name)))
 			cEncountered[r.Table.Name] = true
 		}
 		parentRelations := []string{}
@@ -575,7 +580,12 @@ func (m *Md) makeTableTemplateData(t *schema.Table) map[string]interface{} {
 			if _, ok := pEncountered[r.ParentTable.Name]; ok {
 				continue
 			}
-			parentRelations = append(parentRelations, fmt.Sprintf("[%s](%s%s.md)", r.ParentTable.Name, m.config.BaseURL, mdurl.Encode(r.ParentTable.Name)))
+			// 親テーブルの表示名を決定
+			parentDisplayName := r.ParentTable.Name
+			if m.config.IsTableLogicalNameEnabled() && r.ParentTable.LogicalName != "" && m.config.TableLogicalNameDisplayFormat() != "" {
+				parentDisplayName = r.ParentTable.GetDisplayName(m.config.TableLogicalNameDisplayFormat())
+			}
+			parentRelations = append(parentRelations, fmt.Sprintf("[%s](%s%s.md)", parentDisplayName, m.config.BaseURL, mdurl.Encode(r.ParentTable.Name)))
 			pEncountered[r.ParentTable.Name] = true
 		}
 
@@ -731,6 +741,7 @@ func (m *Md) makeTableTemplateData(t *schema.Table) map[string]interface{} {
 	if adjust {
 		return map[string]interface{}{
 			"Table":            t,
+			"DisplayFormat":    m.config.TableLogicalNameDisplayFormat(),
 			"Columns":          adjustTable(columnsData),
 			"Viewpoints":       adjustTable(viewpointsData),
 			"Constraints":      adjustTable(constraintsData),
@@ -742,6 +753,7 @@ func (m *Md) makeTableTemplateData(t *schema.Table) map[string]interface{} {
 
 	return map[string]interface{}{
 		"Table":            t,
+		"DisplayFormat":    m.config.TableLogicalNameDisplayFormat(),
 		"Columns":          columnsData,
 		"Viewpoints":       viewpointsData,
 		"Constraints":      constraintsData,
@@ -824,8 +836,14 @@ func (m *Md) tablesData(tables []*schema.Table, number, adjust, showOnlyFirstPar
 		if showOnlyFirstParagraph {
 			comment = output.ShowOnlyFirstParagraph(comment)
 		}
+		// テーブル表示名を決定（論理名設定に応じて）
+		displayName := t.Name
+		if m.config.IsTableLogicalNameEnabled() && t.LogicalName != "" && m.config.TableLogicalNameDisplayFormat() != "" {
+			displayName = t.GetDisplayName(m.config.TableLogicalNameDisplayFormat())
+		}
+		
 		d := []string{
-			fmt.Sprintf("[%s](%s%s.md)", t.Name, m.config.BaseURL, mdurl.Encode(t.Name)),
+			fmt.Sprintf("[%s](%s%s.md)", displayName, m.config.BaseURL, mdurl.Encode(t.Name)),
 			fmt.Sprintf("%d", len(t.Columns)),
 			comment,
 			t.Type,

--- a/output/md/templates/table.md.tmpl
+++ b/output/md/templates/table.md.tmpl
@@ -1,4 +1,4 @@
-# {{ .Table.Name }}
+# {{ if and .Table.LogicalName (ne .DisplayFormat "") }}{{ .Table.GetDisplayName .DisplayFormat }}{{ else }}{{ .Table.Name }}{{ end }}
 
 ## {{ "Description" | lookup }}
 {{- if ne .Table.Comment "" }}

--- a/output/mermaid/mermaid.go
+++ b/output/mermaid/mermaid.go
@@ -93,6 +93,7 @@ func (m *Mermaid) OutputTable(wr io.Writer, t *schema.Table) error {
 		"Table":           tables[0],
 		"Tables":          tables[1:],
 		"Relations":       relations,
+		"DisplayFormat":   m.config.TableLogicalNameDisplayFormat(),
 		"showComment":     m.config.ER.Comment,
 		"showDef":         !m.config.ER.HideDef,
 		"showColumnTypes": m.config.ER.ShowColumnTypes,

--- a/output/mermaid/templates/table.mermaid.tmpl
+++ b/output/mermaid/templates/table.mermaid.tmpl
@@ -3,10 +3,10 @@ erDiagram
 {{ $sd := .showDef -}}
 {{- range $j, $r := .Relations }}
 {{- if $r.HideForER }}{{ continue }}{{ end }}
-"{{ $r.Table.Name }}" {{ $r.Cardinality | lcardi }}--{{ $r.ParentCardinality | rcardi }} "{{ $r.ParentTable.Name }}" : "{{ if $sd }}{{ $r.Def }}{{ end }}"
+"{{- if and $r.Table.LogicalName (ne $.DisplayFormat "") }}{{ $r.Table.GetDisplayName $.DisplayFormat }}{{- else }}{{ $r.Table.Name }}{{- end }}" {{ $r.Cardinality | lcardi }}--{{ $r.ParentCardinality | rcardi }} "{{- if and $r.ParentTable.LogicalName (ne $.DisplayFormat "") }}{{ $r.ParentTable.GetDisplayName $.DisplayFormat }}{{- else }}{{ $r.ParentTable.Name }}{{- end }}" : "{{ if $sd }}{{ $r.Def }}{{ end }}"
 {{- end }}
 
-"{{ .Table.Name }}" {
+"{{- if and .Table.LogicalName (ne .DisplayFormat "") }}{{ .Table.GetDisplayName .DisplayFormat }}{{- else }}{{ .Table.Name }}{{- end }}" {
 {{- range $i, $c := .Table.Columns }}
   {{- if $c.HideForER }}{{ continue }}{{ end }}
   {{ $c.Type | escape_mermaid }} {{ $c.Name }}{{ if $c.HasLogicalName }}_{{ $c.LogicalName | escape_double_quote }}{{ end }}{{ if $c.PK }} PK{{ end }}{{ if $c.FK }} FK{{ end }}{{ if $sc }} "{{ if ne $c.Comment "" }}{{ $c.Comment | escape_nl | escape_double_quote }}{{ end }}"{{ end }}
@@ -14,7 +14,7 @@ erDiagram
 }
 
 {{- range $i, $t := .Tables }}
-"{{ $t.Name }}" {
+"{{- if and $t.LogicalName (ne $.DisplayFormat "") }}{{ $t.GetDisplayName $.DisplayFormat }}{{- else }}{{ $t.Name }}{{- end }}" {
 {{- range $ii, $c := $t.Columns }}
   {{- if $c.HideForER }}{{ continue }}{{ end }}
   {{ $c.Type | escape_mermaid }} {{ $c.Name }}{{ if $c.HasLogicalName }}_{{ $c.LogicalName | escape_double_quote }}{{ end }}{{ if $c.PK }} PK{{ end }}{{ if $c.FK }} FK{{ end }}{{ if $sc }} "{{ if ne $c.Comment "" }}{{ $c.Comment | escape_nl | escape_double_quote }}{{ end }}"{{ end }}

--- a/output/plantuml/plantuml.go
+++ b/output/plantuml/plantuml.go
@@ -93,6 +93,7 @@ func (p *PlantUML) OutputTable(wr io.Writer, t *schema.Table) error {
 		"Table":           tables[0],
 		"Tables":          tables[1:],
 		"Relations":       relations,
+		"DisplayFormat":   p.config.TableLogicalNameDisplayFormat(),
 		"showComment":     p.config.ER.Comment,
 		"showDef":         !p.config.ER.HideDef,
 		"showColumnTypes": p.config.ER.ShowColumnTypes,

--- a/output/plantuml/templates/table.puml.tmpl
+++ b/output/plantuml/templates/table.puml.tmpl
@@ -15,9 +15,9 @@ skinparam class {
 
 ' tables
 {{- if ne .Table.Type "VIEW" }}
-table("{{ .Table.Name }}", "{{ .Table.Name }}{{ if $sc }}{{ if ne .Table.Comment "" }}\n{{ .Table.Comment | html | escape_nl }}{{ end }}{{ end }}") {
+table("{{ .Table.Name }}", "{{- if and .Table.LogicalName (ne .DisplayFormat "") }}{{ .Table.GetDisplayName .DisplayFormat }}{{- else }}{{ .Table.Name }}{{- end }}{{ if $sc }}{{ if ne .Table.Comment "" }}\n{{ .Table.Comment | html | escape_nl }}{{ end }}{{ end }}") {
 {{- else }}
-view("{{ .Table.Name }}", "{{ .Table.Name }}{{ if $sc }}{{ if ne .Table.Comment "" }}\n{{ .Table.Comment | html | escape_nl }}{{ end }}{{ end }}") {
+view("{{ .Table.Name }}", "{{- if and .Table.LogicalName (ne .DisplayFormat "") }}{{ .Table.GetDisplayName .DisplayFormat }}{{- else }}{{ .Table.Name }}{{- end }}{{ if $sc }}{{ if ne .Table.Comment "" }}\n{{ .Table.Comment | html | escape_nl }}{{ end }}{{ end }}") {
 {{- end }}
 {{- range $i, $c := .Table.Columns }}
   {{- if $c.HideForER }}{{ continue }}{{ end }}
@@ -26,9 +26,9 @@ view("{{ .Table.Name }}", "{{ .Table.Name }}{{ if $sc }}{{ if ne .Table.Comment 
 }
 {{- range $i, $t := .Tables }}
 {{- if ne $t.Type "VIEW" }}
-table("{{ $t.Name }}", "{{ $t.Name }}{{ if $sc }}{{ if ne $t.Comment "" }}\n{{ $t.Comment | html | escape_nl }}{{ end }}{{ end }}") {
+table("{{ $t.Name }}", "{{- if and $t.LogicalName (ne $.DisplayFormat "") }}{{ $t.GetDisplayName $.DisplayFormat }}{{- else }}{{ $t.Name }}{{- end }}{{ if $sc }}{{ if ne $t.Comment "" }}\n{{ $t.Comment | html | escape_nl }}{{ end }}{{ end }}") {
 {{- else }}
-view("{{ $t.Name }}", "{{ $t.Name }}{{ if $sc }}{{ if ne $t.Comment "" }}\n{{ $t.Comment | html | escape_nl }}{{ end }}{{ end }}") {
+view("{{ $t.Name }}", "{{- if and $t.LogicalName (ne $.DisplayFormat "") }}{{ $t.GetDisplayName $.DisplayFormat }}{{- else }}{{ $t.Name }}{{- end }}{{ if $sc }}{{ if ne $t.Comment "" }}\n{{ $t.Comment | html | escape_nl }}{{ end }}{{ end }}") {
 {{- end }}
 {{- range $ii, $c := $t.Columns }}
   {{- if $c.HideForER }}{{ continue }}{{ end }}


### PR DESCRIPTION
## 概要
Issue #27「サブタスク4: テンプレートの更新（テーブル論理名表示）」の実装です。
親タスク #23「機能要求: テーブル名論理名対応」の第4サブタスクとして、全出力フォーマットでテーブル論理名の表示を実装しました。

## 実装内容

### 1. テンプレートファイルの更新
- `output/md/templates/table.md.tmpl`: テーブル名を論理名表示に対応
- `output/plantuml/templates/table.puml.tmpl`: PlantUMLでのテーブル名表示を論理名対応  
- `output/mermaid/templates/table.mermaid.tmpl`: Mermaidでのテーブル名表示を論理名対応
- `output/dot/templates/table.dot.tmpl`: Dotでのテーブル名表示を論理名対応

### 2. 出力処理の更新
- `output/md/md.go`: `DisplayFormat`パラメータを追加し、テーブル一覧とparent/child relationで論理名表示
- `output/plantuml/plantuml.go`: `DisplayFormat`パラメータを追加
- `output/mermaid/mermaid.go`: `DisplayFormat`パラメータを追加  
- `output/dot/dot.go`: `DisplayFormat`パラメータを追加

### 3. 実装された機能
- ✅ テーブルページでのヘッダー論理名表示
- ✅ README.mdのテーブル一覧での論理名表示
- ✅ カラムのparent/child relationリンクでの論理名表示
- ✅ 全出力フォーマット（MD、PlantUML、Mermaid、Dot）での論理名対応
- ✅ DisplayFormat設定（`physical_logical`、`logical_physical`）に応じた表示切り替え
- ✅ 設定無効時は従来通りの表示を維持

## 表示例

### 設定: physical_logical
```markdown
# public.users（ユーザーマスタ）

## 説明
システムのユーザー情報を管理
```

### 設定: logical_physical  
```markdown
# ユーザーマスタ（public.users）

## 説明
システムのユーザー情報を管理
```

### 設定無効時（従来通り）
```markdown
# public.users

## 説明
ユーザーマスタ|システムのユーザー情報を管理
```

## テスト結果
- ✅ MD出力テスト: PASS
- ✅ PlantUML出力テスト: PASS  
- ✅ Mermaid出力テスト: PASS
- ✅ Dot出力テスト: PASS
- ✅ ビルドテスト: PASS

## 受け入れ条件
- [x] table.md.tmplでテーブル論理名が表示される
- [x] DisplayFormat設定に応じて表示形式が切り替わる
- [x] README.mdのテーブル一覧でも論理名が表示される
- [x] 他の出力フォーマット（PlantUML、Mermaid、Dot）でも論理名が表示される  
- [x] 設定無効時は従来通りの表示になる
- [x] テンプレート関数が正しく動作する

## 関連Issue
- Closes #27 サブタスク4: テンプレートの更新（テーブル論理名表示）
- Related to #23 機能要求: テーブル名論理名対応

## 依存関係
- ✅ #24 サブタスク1: テーブル論理名設定オプションの追加（実装済み）
- ✅ #25 サブタスク2: テーブルコメント分割ロジックの実装（実装済み）  
- ✅ #26 サブタスク3: データベースドライバーのテーブルコメント処理更新（実装済み）

🤖 Generated with [Claude Code](https://claude.ai/code)